### PR TITLE
Fixes to Makefile

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v5.0.1"
 
 [[projects]]
-  digest = "1:0e6a07d43e760104f43bc2c7b63116a3fa74b25c4281bcb84d2cd984cb69ad5c"
+  digest = "1:c4457d3d55683a5d92ddb931967bf89c2654a16efd54484286f437017a336fb1"
   name = "github.com/goadesign/goa"
   packages = [
     ".",
@@ -47,7 +47,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a3d1e57e77a1fc2313a5e83f34b843e322e59007ec5e8c92e670e5505b71379f"
+  digest = "1:44226bc21fe648a56999a489e6177732545f89c277a34cf4e5980ff2d47fe632"
   name = "github.com/graph-gophers/graphql-go"
   packages = [
     ".",
@@ -84,7 +84,7 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
+  digest = "1:27af6024faa3c28426a698b8c653be0fd908bc96e25b7d76f2192eb342427db6"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -113,7 +113,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:290b8002a96a5f5c1bd8316884f6e2414f5fb1e46a22bbd5a1ff0d45dc944cb3"
+  digest = "1:9d77f120e50e5134d4256d87f77a14022c9b624433e8bd8f4ed72be800d5fb61"
   name = "golang.org/x/net"
   packages = [
     "context",

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
 M = $(shell printf "\033[34;1m▶\033[0m")
 
-build: dep ; $(info $(M) Building project...)
+.PHONY: build
+build: vendor/ schema ; $(info $(M) Building project...)
 	go build ./...
 
+.PHONY: clean
 clean: ; $(info $(M) [TODO] Removing generated files... )
 	$(RM) schema/bindata.go
+	$(RM) -rf vendor/
 
-dep: setup ; $(info $(M) Ensuring vendored dependencies are up-to-date...)
-	dep ensure
+.PHONY: schema
+schema: schema/bindata.go ; $(info $(M) Embedding schema files into binary...)
 
-schema: dep ; $(info $(M) Embedding schema files into binary...)
+schema/bindata.go: vendor/ ./schema/*.graphql ./schema/types/*.graphql
 	PATH=$(GOPATH)/bin:$(PATH) go generate ./schema
 
-setup: ; $(info $(M) Fetching github.com/golang/dep...)
+vendor/: Gopkg.toml Gopkg.lock ; $(info $(M) Fetching dependencies...)
 	go get github.com/golang/dep/cmd/dep
 	go get -u github.com/jteeuwen/go-bindata/...
+	dep ensure
 
+.PHONY: server
 server: schema ; $(info $(M) Starting development server...)
 	go run main.go
-
-.PHONY: dep schema build clean container image setup server

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build: vendor/ schema ; $(info $(M) Building project...)
 	go build ./...
 
 .PHONY: clean
-clean: ; $(info $(M) [TODO] Removing generated files... )
+clean: ; $(info $(M) Removing generated files... )
 	$(RM) schema/bindata.go
 	$(RM) -rf vendor/
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -4,11 +4,8 @@ package schema
 
 import "bytes"
 
-// String reads the .graphql schema files from the generated _bindata.go file, concatenating the
-// files together into one string.
-//
-// If this method complains about not finding functions AssetNames() or MustAsset(),
-// run `go generate` against this package to generate the functions.
+// String reads the .graphql schema files from the generated _bindata.go file,
+// concatenating the files together into one string.
 func String() string {
 	buf := bytes.Buffer{}
 	for _, name := range AssetNames() {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,4 +1,5 @@
 //go:generate go-bindata -ignore=\.go -pkg=schema -o=bindata.go ./...
+
 package schema
 
 import "bytes"


### PR DESCRIPTION
This change includes mostly Makefile related changes and two other things:

* Restructure Makefile to compile on first try without the need to manually call `go generate`:
    - have individual `.PHONY`s in Makefile for easier maintenance of all targets
      (for example, there was an `image` `.PHONY` but no target called `image` existed).
    - have a recipe for `vendor/` and `schema/bindata.go` that list all the dependencies accordingly
    - make the `schema` target a dependent for the `build` target
    - remove no longer needed comment on `schema/schema.go` because we will (re-)generate `schema/bindata.go` whenever any of the `*.graphql` files in `./schema` or `./schema/types` changes.
* Go generate comment should not be treated as a package comment so I've put an empty line in between the comment and the `package schema` line.
* Updated digests in Gopkg.lock